### PR TITLE
refactor(gitignore): Add c9 to gitignore

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/gitignore
+++ b/packages/angular-cli/blueprints/ng2/files/gitignore
@@ -13,6 +13,7 @@
 /.vscode
 .project
 .classpath
+.c9
 *.launch
 .settings/
 


### PR DESCRIPTION
Adding `.c9` to `.gitignore`. 

`.c9` is from Cloud9 IDE, an editor in the browser. Partnered with Google to [connect Google App Engine apps](https://c9.io/blog/build-apps-for-google-cloud-platform-on-cloud9/). [Purchased by Amazon](https://c9.io/blog/great-news/) a month ago. The best way to code on a Chromebook.